### PR TITLE
Debug output component issue

### DIFF
--- a/apps/PlayaTewsIdentityMasker/backend/EnhancedStreamOutput.py
+++ b/apps/PlayaTewsIdentityMasker/backend/EnhancedStreamOutput.py
@@ -680,7 +680,7 @@ class Sheet:
 
 
 class WorkerState(BackendWorkerState):
-    source_type : SourceType = None
+    source_type : SourceType = SourceType.SOURCE_FRAME
     is_showing_window : bool = None
     aligned_face_id : int = None
     target_delay : int = None

--- a/apps/PlayaTewsIdentityMasker/backend/StreamOutput.py
+++ b/apps/PlayaTewsIdentityMasker/backend/StreamOutput.py
@@ -358,7 +358,7 @@ class Sheet:
             self.stream_port = lib_csw.Number.Host()
 
 class WorkerState(BackendWorkerState):
-    source_type : SourceType = None
+    source_type : SourceType = SourceType.SOURCE_FRAME
     is_showing_window : bool = None
     aligned_face_id : int = None
     target_delay : int = None

--- a/output_component_investigation.md
+++ b/output_component_investigation.md
@@ -1,0 +1,137 @@
+# Output Component Investigation Report
+
+## Issue Summary
+The output component is not working properly due to the `source_type` selection defaulting to `None` and never being properly initialized to a valid value.
+
+## Root Cause Analysis
+
+### Problem Location
+- **Files affected**: 
+  - `apps/PlayaTewsIdentityMasker/backend/StreamOutput.py`
+  - `apps/PlayaTewsIdentityMasker/backend/EnhancedStreamOutput.py`
+  - `apps/PlayaTewsIdentityMasker/ui/widgets/QComboBoxCSWDynamicSingleSwitch.py`
+
+### Specific Issues Found
+
+1. **Initialization Problem**: 
+   - `WorkerState.source_type` is initialized as `None` in both StreamOutput classes
+   - When `cs.source_type.select(state.source_type)` is called with `None`, the UI shows "None" selected
+   - This causes the log entries: `QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None`
+
+2. **Logic Flow Issue**:
+   - The `on_cs_source_type` handler is only triggered when a user manually selects a value
+   - No default selection is made automatically during initialization
+   - This leaves the output component in an unusable state
+
+### Evidence from Logs
+```
+QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None
+QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None
+QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None
+QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None
+```
+
+### Code Analysis
+
+#### Current Problematic Flow:
+1. `WorkerState` sets `source_type : SourceType = None`
+2. During initialization: `cs.source_type.select(state.source_type)` called with `None`
+3. UI shows "None" selected and logs the issue
+4. Output component cannot function without a valid source type
+
+#### Available Source Types:
+```python
+class SourceType(IntEnum):
+    SOURCE_FRAME = 0
+    ALIGNED_FACE = 1
+    SWAPPED_FACE = 2
+    MERGED_FRAME = 3
+    MERGED_FRAME_OR_SOURCE_FRAME = 4
+    SOURCE_N_MERGED_FRAME = 5
+    SOURCE_N_MERGED_FRAME_OR_SOURCE_FRAME = 6
+    ALIGNED_N_SWAPPED_FACE = 7
+```
+
+## Recommended Solution
+
+### Option 1: Set Default in WorkerState (Recommended)
+Change the WorkerState initialization to set a sensible default:
+
+```python
+class WorkerState(BackendWorkerState):
+    source_type : SourceType = SourceType.SOURCE_FRAME  # Default to SOURCE_FRAME
+    # ... rest of the fields
+```
+
+### Option 2: Set Default During Initialization
+Add logic to set a default if source_type is None during initialization:
+
+```python
+cs.source_type.enable()
+cs.source_type.set_choices(SourceType, ViewModeNames, none_choice_name='@misc.menu_select')
+# Set default if None
+if state.source_type is None:
+    state.source_type = SourceType.SOURCE_FRAME
+cs.source_type.select(state.source_type)
+```
+
+### Option 3: Force Initial Selection
+Add code to programmatically trigger the selection handler:
+
+```python
+cs.source_type.select(state.source_type)
+# If still None, force a default selection
+if state.source_type is None:
+    cs.source_type.select(SourceType.SOURCE_FRAME)
+```
+
+## Recommended Implementation
+
+I recommend **Option 1** as it's the cleanest solution and ensures the component always has a valid state from the beginning.
+
+## Files to Modify
+
+1. **`apps/PlayaTewsIdentityMasker/backend/StreamOutput.py`** - Line 360
+2. **`apps/PlayaTewsIdentityMasker/backend/EnhancedStreamOutput.py`** - Line 682
+
+## Solution Applied ✅
+
+The recommended fix has been successfully implemented:
+
+### Changes Made:
+1. **`apps/PlayaTewsIdentityMasker/backend/StreamOutput.py`** - Line 360:
+   ```python
+   # Changed from:
+   source_type : SourceType = None
+   # Changed to:
+   source_type : SourceType = SourceType.SOURCE_FRAME
+   ```
+
+2. **`apps/PlayaTewsIdentityMasker/backend/EnhancedStreamOutput.py`** - Line 682:
+   ```python
+   # Changed from:
+   source_type : SourceType = None
+   # Changed to:
+   source_type : SourceType = SourceType.SOURCE_FRAME
+   ```
+
+### Validation Results:
+- ✅ StreamOutput: source_type default is correctly set to SourceType.SOURCE_FRAME
+- ✅ EnhancedStreamOutput: source_type default is correctly set to SourceType.SOURCE_FRAME
+
+## Expected Results
+
+After implementing the fix:
+1. ✅ The UI will no longer show "None" selected by default
+2. ✅ The log file won't contain `QComboBoxCSWDynamicSingleSwitch: Selected None, choice: None`
+3. ✅ The output component will function correctly with the default SOURCE_FRAME source type
+4. ✅ Manual selection will continue to work properly
+
+## Testing
+
+To verify the fix works in the application:
+1. Start the application
+2. Navigate to the Stream Output component
+3. Verify that "SOURCE_FRAME" is selected by default instead of "None"
+4. Check that no "Selected None, choice: None" messages appear in the logs
+5. Confirm the output component functions correctly


### PR DESCRIPTION
Set default `source_type` to `SOURCE_FRAME` to fix output component not working on startup.

The `source_type` in `WorkerState` was initialized as `None`, leading to the UI displaying 'None' by default and preventing the output component from functioning until a manual selection was made. This change provides a sensible default, making the component immediately usable.